### PR TITLE
fix: chmod wireguard wgnord

### DIFF
--- a/wgnord
+++ b/wgnord
@@ -82,6 +82,7 @@ connect() {
 
 	privkey="$(jq -j '.nordlynx_private_key' $conf_dir/credentials.json)"
 	sed -e "s|PRIVKEY|$privkey|" -e "s|SERVER_PUBKEY|$server_pubkey|" -e "s|SERVER_IP|$server_ip|" $conf_dir/template.conf > "$out_file"
+	chmod 600 "$out_file"
 	if [ ! $dont_act ]; then
 		print "Connecting to $server_hostname ($server_name)..."
 		if is_connected; then


### PR DESCRIPTION
Pull PR [origin #12](https://github.com/phirecc/wgnord/pull/12) into master of this fork.
We chmod wgnord.conf to only user rw to suppress the wg-quick warning.
PR by [github@oldgit](https://github.com/oldgit) originally made in upstream, pulling fork ahead. 